### PR TITLE
FFT: Operations->Operation. Now only generate one code wall

### DIFF
--- a/core/jsonlogic.cabal
+++ b/core/jsonlogic.cabal
@@ -28,7 +28,7 @@ library
     exposed-modules:
         JsonLogic,
         JsonLogic.Json,
-        JsonLogic.Operations
+        JsonLogic.Operation
     other-modules:
         JsonLogic.JL,
         JsonLogic.Operation.Var

--- a/core/src/JsonLogic.hs
+++ b/core/src/JsonLogic.hs
@@ -12,7 +12,7 @@ import JsonLogic.Json
     Result,
     Rule,
   )
-import JsonLogic.Operations (Operation, createEnv)
+import JsonLogic.Operation (Operation, createEnv)
 
 -- evaluate JsonLogic without bothering about monads
 eval :: [Operation] -> Rule -> Data -> Result

--- a/core/src/JsonLogic/Operation.hs
+++ b/core/src/JsonLogic/Operation.hs
@@ -1,4 +1,4 @@
-module JsonLogic.Operations where
+module JsonLogic.Operation where
 
 import Control.Monad.Except (MonadError (throwError))
 import Data.Map as M hiding (map)


### PR DESCRIPTION
Resolves: #40 

Just substituting the (+) with the definition
Now prelude does not need to get imported qualified anymore.
